### PR TITLE
Post merge fixes:

### DIFF
--- a/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
+++ b/src/main/java/org/ohdsi/webapi/service/CohortDefinitionService.java
@@ -32,6 +32,7 @@ import org.ohdsi.webapi.cohortdefinition.CohortGenerationInfo;
 import org.ohdsi.webapi.cohortdefinition.ExpressionType;
 import org.ohdsi.webapi.cohortdefinition.GenerateCohortTask;
 import org.ohdsi.webapi.cohortdefinition.GenerateCohortTasklet;
+import org.ohdsi.webapi.cohortdefinition.GenerationStatus;
 import org.ohdsi.webapi.job.JobExecutionResource;
 import org.ohdsi.webapi.job.JobTemplate;
 import org.springframework.batch.core.JobParameters;
@@ -254,7 +255,17 @@ public class CohortDefinitionService extends AbstractDaoService {
     public JobExecutionResource generateCohort(@PathParam("id") final int id) {
 
       CohortDefinition currentDefinition = this.cohortDefinitionRepository.findOneWithDetail(id);
-      
+      CohortGenerationInfo info = currentDefinition.getGenerationInfo();
+      if (info == null)
+      {
+        info = new CohortGenerationInfo().setCohortDefinition(currentDefinition);
+        currentDefinition.setGenerationInfo(info);
+      }
+      info.setStatus(GenerationStatus.PENDING)
+        .setStartTime(Calendar.getInstance().getTime());
+
+      this.cohortDefinitionRepository.save(currentDefinition);
+    
       JobParametersBuilder builder = new JobParametersBuilder();
       builder.addString("cohort_definition_id", ("" + id));
       final JobParameters jobParameters = builder.toJobParameters();

--- a/src/main/resources/resources/cohortdefinition/sql/procedureOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/procedureOccurrence.sql
@@ -1,4 +1,4 @@
-select C.person_id, C.procedure_date as start_date, DATEADD(d,1,C.procedure_date) as END_DATE
+select C.person_id, C.procedure_date as start_date, DATEADD(d,1,C.procedure_date) as END_DATE, C.procedure_concept_id as TARGET_CONCEPT_ID
 from 
 (
   select po.*, ROW_NUMBER() over (PARTITION BY po.person_id ORDER BY po.procedure_date) as ordinal


### PR DESCRIPTION
procedureOccurrence didn't expose TARGET_CONCEPT_ID (used for additional criteria elements)
Added CohortGenerationInfo at the time of generation (endpoint /chortdefinition/{id}/generate because a client UI could poll for generation status before the job launches and think that there nos no outstanding jobs for this cohort.  This ensures that the status is 'Pending' by the end of the return from /generate.
